### PR TITLE
chore: add php-http/discovery to allow-plugins list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
             "drupal/core-composer-scaffold": true,
             "drupal/core-project-message": true,
             "phpstan/extension-installer": true,
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "php-http/discovery": true
         }
     },
     "extra": {


### PR DESCRIPTION
Otherwise, composer will ask about the plugin on the first `composer install`.